### PR TITLE
Bugfix/74/flipped sprite rendering

### DIFF
--- a/Common/src/main/java/dk/sdu/sesem4/common/data/EntityParts/SpritePart.java
+++ b/Common/src/main/java/dk/sdu/sesem4/common/data/EntityParts/SpritePart.java
@@ -4,9 +4,14 @@ import dk.sdu.sesem4.common.data.entity.Entity;
 import dk.sdu.sesem4.common.data.gamedata.GameData;
 import dk.sdu.sesem4.common.data.rendering.SpriteData;
 
+import java.util.UUID;
+
 public class SpritePart implements EntityPart {
 	/** Current sprite for entity */
 	private SpriteData sprite;
+
+	/** Id */
+	private final UUID id;
 
 	/**
 	 * Construct SpritePart with sprite
@@ -15,6 +20,7 @@ public class SpritePart implements EntityPart {
 	 */
 	public SpritePart(SpriteData sprite) {
 		this.sprite = sprite;
+		this.id = UUID.randomUUID();
 	}
 
 	public SpriteData getSprite() {
@@ -23,6 +29,10 @@ public class SpritePart implements EntityPart {
 
 	public void setSprite(SpriteData sprite) {
 		this.sprite = sprite;
+	}
+
+	public UUID getId() {
+		return id;
 	}
 
 	@Override

--- a/Common/src/main/java/dk/sdu/sesem4/common/data/EntityParts/SpritePart.java
+++ b/Common/src/main/java/dk/sdu/sesem4/common/data/EntityParts/SpritePart.java
@@ -4,14 +4,9 @@ import dk.sdu.sesem4.common.data.entity.Entity;
 import dk.sdu.sesem4.common.data.gamedata.GameData;
 import dk.sdu.sesem4.common.data.rendering.SpriteData;
 
-import java.util.UUID;
-
 public class SpritePart implements EntityPart {
 	/** Current sprite for entity */
 	private SpriteData sprite;
-
-	/** Id */
-	private final UUID id;
 
 	/**
 	 * Construct SpritePart with sprite
@@ -20,7 +15,6 @@ public class SpritePart implements EntityPart {
 	 */
 	public SpritePart(SpriteData sprite) {
 		this.sprite = sprite;
-		this.id = UUID.randomUUID();
 	}
 
 	public SpriteData getSprite() {
@@ -29,10 +23,6 @@ public class SpritePart implements EntityPart {
 
 	public void setSprite(SpriteData sprite) {
 		this.sprite = sprite;
-	}
-
-	public UUID getId() {
-		return id;
 	}
 
 	@Override

--- a/Common/src/main/java/dk/sdu/sesem4/common/data/rendering/SpriteData.java
+++ b/Common/src/main/java/dk/sdu/sesem4/common/data/rendering/SpriteData.java
@@ -13,8 +13,6 @@ public class SpriteData {
 	private boolean yFlipped;
 	/** Ressource location, of the sprite texture */
 	private Class<?> ressourceClass;
-	/** Unique id for sprite */
-	private final UUID id;
 
 	/**
 	 * Construct a SpriteData based on texture, if flipped x and if flipped y.
@@ -32,7 +30,6 @@ public class SpriteData {
 		this.xFlipped = xFlipped;
 		this.yFlipped = yFlipped;
 		this.ressourceClass = ressourceClass;
-		this.id = UUID.randomUUID();
 	}
 	
 	/**
@@ -78,11 +75,6 @@ public class SpriteData {
 
 	public Class<?> getRessourceClass() {
 		return this.ressourceClass;
-	}
-
-
-	public UUID getId() {
-		return id;
 	}
 
 }

--- a/Common/src/main/java/dk/sdu/sesem4/common/data/rendering/SpriteData.java
+++ b/Common/src/main/java/dk/sdu/sesem4/common/data/rendering/SpriteData.java
@@ -2,7 +2,6 @@ package dk.sdu.sesem4.common.data.rendering;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.UUID;
 
 public class SpriteData {
 	/** Path for the texture of the sprite */

--- a/Common/src/main/java/dk/sdu/sesem4/common/data/rendering/SpriteData.java
+++ b/Common/src/main/java/dk/sdu/sesem4/common/data/rendering/SpriteData.java
@@ -2,6 +2,7 @@ package dk.sdu.sesem4.common.data.rendering;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.UUID;
 
 public class SpriteData {
 	/** Path for the texture of the sprite */
@@ -10,7 +11,11 @@ public class SpriteData {
 	private boolean xFlipped;
 	/** Sprite is flipped on the y-axis */
 	private boolean yFlipped;
-	
+	/** Ressource location, of the sprite texture */
+	private Class<?> ressourceClass;
+	/** Unique id for sprite */
+	private final UUID id;
+
 	/**
 	 * Construct a SpriteData based on texture, if flipped x and if flipped y.
 	 *
@@ -19,9 +24,15 @@ public class SpriteData {
 	 * @param yFlipped True if sprite should be flipped on the y-axis
 	 */
 	public SpriteData(Path texture, boolean xFlipped, boolean yFlipped) {
+		this(texture, xFlipped, yFlipped, null);
+	}
+
+	public SpriteData(Path texture, boolean xFlipped, boolean yFlipped, Class<?> ressourceClass) {
 		this.texture = texture;
 		this.xFlipped = xFlipped;
 		this.yFlipped = yFlipped;
+		this.ressourceClass = ressourceClass;
+		this.id = UUID.randomUUID();
 	}
 	
 	/**
@@ -64,4 +75,14 @@ public class SpriteData {
 	public void setYFlipped(boolean yFlipped) {
 		this.yFlipped = yFlipped;
 	}
+
+	public Class<?> getRessourceClass() {
+		return this.ressourceClass;
+	}
+
+
+	public UUID getId() {
+		return id;
+	}
+
 }

--- a/Common/src/main/java/dk/sdu/sesem4/common/data/rendering/SpriteData.java
+++ b/Common/src/main/java/dk/sdu/sesem4/common/data/rendering/SpriteData.java
@@ -11,13 +11,13 @@ public class SpriteData {
 	private boolean xFlipped;
 	/** Sprite is flipped on the y-axis */
 	private boolean yFlipped;
-	/** Ressource location, of the sprite texture */
-	private Class<?> ressourceClass;
+	/** Resource location, of the sprite texture */
+	private Class<?> resourceClass;
 
 	/**
 	 * Construct a SpriteData based on texture, if flipped x and if flipped y.
 	 *
-	 * @param texture Path for texture
+	 * @param texture  Path for texture
 	 * @param xFlipped True if sprite should be flipped on the x-axis
 	 * @param yFlipped True if sprite should be flipped on the y-axis
 	 */
@@ -25,56 +25,59 @@ public class SpriteData {
 		this(texture, xFlipped, yFlipped, null);
 	}
 
-	public SpriteData(Path texture, boolean xFlipped, boolean yFlipped, Class<?> ressourceClass) {
+	public SpriteData(Path texture, boolean xFlipped, boolean yFlipped, Class<?> resourceClass) {
 		this.texture = texture;
 		this.xFlipped = xFlipped;
 		this.yFlipped = yFlipped;
-		this.ressourceClass = ressourceClass;
+		this.resourceClass = resourceClass;
 	}
-	
+
 	/**
-	 * Construct a SpriteData based on the path for the texture of the sprite, where xFlipped and yFlipped are false as default.
+	 * Construct a SpriteData based on the path for the texture of the sprite, where
+	 * xFlipped and yFlipped are false as default.
+	 * 
 	 * @param texture Path for texture
 	 */
 	public SpriteData(Path texture) {
 		this(texture, false, false);
 	}
-	
+
 	/**
-	 * Construct a SpriteData based on file name og string representing the file path.
+	 * Construct a SpriteData based on file name og string representing the file
+	 * path.
 	 *
 	 * @param fileName String file path
 	 */
 	public SpriteData(String fileName) {
 		this(Paths.get(fileName));
 	}
-	
+
 	public Path getTexture() {
 		return texture;
 	}
-	
+
 	public void setTexture(Path texture) {
 		this.texture = texture;
 	}
-	
+
 	public boolean isxFlipped() {
 		return xFlipped;
 	}
-	
+
 	public boolean isyFlipped() {
 		return yFlipped;
 	}
-	
+
 	public void setXFlipped(boolean xFlipped) {
 		this.xFlipped = xFlipped;
 	}
-	
+
 	public void setYFlipped(boolean yFlipped) {
 		this.yFlipped = yFlipped;
 	}
 
-	public Class<?> getRessourceClass() {
-		return this.ressourceClass;
+	public Class<?> getResourceClass() {
+		return this.resourceClass;
 	}
 
 }

--- a/Common/src/main/java/dk/sdu/sesem4/common/data/resource/Resource.java
+++ b/Common/src/main/java/dk/sdu/sesem4/common/data/resource/Resource.java
@@ -1,0 +1,266 @@
+package dk.sdu.sesem4.common.data.resource;
+
+import java.io.*;
+import java.net.URL;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Get resource from system.
+ *
+ * @author The0Mikkel & MGertz
+ */
+public class Resource {
+	/** Resource file prefix. */
+    private static final String resourcePrefix = "/";
+	/** Temporary file name prefix. */
+    private static final String tmpFilePrefix = "Nelda";
+	/** Temporary file format. */
+    private static final String tmpFileFormat = "tmp";
+	/** Instance of the resource system. */
+    private static Resource instance;
+	/** Map of path UUIDs based on class and path. */
+    private Map<Class<?>, Map<Path, UUID>> pathUUID;
+	/** File cache, to prevent duplicate temporary files. */
+    private Map<UUID, File> fileCache;
+
+    private Resource() {
+        this.pathUUID = new HashMap<>();
+        this.fileCache = new HashMap<>();
+    }
+
+	/**
+	 * Get ressource instance.
+	 *
+	 * @return Resource instance.
+	 */
+    public static Resource getInstance() {
+        if (Resource.instance == null) {
+            Resource.instance = new Resource();
+        }
+        return Resource.instance;
+    }
+
+	/**
+	 * Invalidate the current cache, and delete all current files used by the system.
+	 *
+	 * @throws IOException Can be thrown by the deletion process.
+	 */
+    public void invalidateCache() throws IOException {
+        this.pathUUID = new HashMap<>();
+
+        this.fileCache.forEach((uuid, file) -> file.delete());
+        this.fileCache = new HashMap<>();
+    }
+
+	/**
+	 * Delete specific cached file
+	 *
+	 * @param file File object to delete
+	 */
+	public void deleteFile(File file) {
+		this.fileCache.values().remove(file);
+	}
+
+	/**
+	 * Get a ressource file as a File.
+	 *
+	 * @param ressourceClass Class which represents where the file is located
+	 * @param path Path for the ressource
+	 *
+	 * @return File that has been retrieved from ressources
+	 */
+    public File getRessource(Class<?> ressourceClass, Path path) {
+        // Ensure valid values
+        if (ressourceClass == null || path == null) {
+            return null;
+        }
+
+		// Get cached file
+        File cachedFile = getCachedFile(ressourceClass, path);
+        if (cachedFile != null) {
+            return cachedFile;
+        }
+
+		// Generate tmp file
+        UUID uuid = generatePathUUID(ressourceClass, path);
+        File file = generateTmpFile(ressourceClass, path, uuid);
+        if (file == null) {
+            return null;
+        }
+		cacheFile(uuid, file);
+
+        return file;
+    }
+
+	/**
+	 * Check if a ressource exists. This does not check cache.
+	 *
+	 * @param ressourceClass Class which represents where the file is located
+	 * @param path Path for the ressource
+	 *
+	 * @return Boolean representing if the ressource actually exists. True indicates the ressource is locatable.
+	 */
+    public static boolean exists(Class<?> ressourceClass, Path path) {
+        if (ressourceClass == null || path == null) {
+            return false;
+        }
+
+        URL url = getRessourceAsURL(ressourceClass, path);
+        return url != null;
+    }
+
+	/**
+	 * Get cached file
+	 *
+	 * @param ressourceClass Class which represents where the file is located
+	 * @param path Path for the ressource
+	 *
+	 * @return Cached file or null if no cached file exist
+	 */
+    private File getCachedFile(Class<?> ressourceClass, Path path) {
+        return this.getCachedFile(this.getPathUUID(ressourceClass, path));
+    }
+
+	/**
+	 * Get cached file
+	 *
+	 * @param uuid UUID representing the cached file
+	 *
+	 * @return Cached file or null if no cached file exist
+	 */
+    private File getCachedFile(UUID uuid) {
+        if (!this.fileCache.containsKey(uuid)) {
+            return null;
+        }
+
+        return this.fileCache.get(uuid);
+    }
+
+	/**
+	 * Cache file
+	 *
+	 * @param uuid Representing file
+	 * @param file File to cache
+	 */
+    private void cacheFile(UUID uuid, File file) {
+        this.fileCache.put(uuid, file);
+    }
+
+	/**
+	 * Get path UUID, based resource class and path
+	 *
+	 * @param ressourceClass Class which represents where the file is located
+	 * @param path Path for the ressource
+	 *
+	 * @return UUID representing the unique path
+	 */
+    private UUID getPathUUID(Class<?> ressourceClass, Path path) {
+        if (!this.pathUUID.containsKey(ressourceClass)) {
+            return null;
+        }
+
+        Map<Path, UUID> ressourceClassUUIDs = this.pathUUID.get(ressourceClass);
+        if (!ressourceClassUUIDs.containsKey(path)) {
+            return null;
+        }
+
+        return ressourceClassUUIDs.get(path);
+    }
+
+	/**
+	 * Generate path UUID, based resource class and path
+	 *
+	 * @param ressourceClass Class which represents where the file is located
+	 * @param path Path for the ressource
+	 *
+	 * @return UUID representing the unique path
+	 */
+    private UUID generatePathUUID(Class<?> ressourceClass, Path path) {
+        UUID existingUUID = getPathUUID(ressourceClass, path);
+        if (existingUUID != null) {
+            return existingUUID;
+        }
+
+        UUID uuid = UUID.randomUUID();
+        storePathUUID(ressourceClass, path, uuid);
+        return uuid;
+    }
+
+	/**
+	 * Store path UUID
+	 *
+	 * @param ressourceClass Class which represents where the file is located
+	 * @param path Path for the ressource
+	 * @param uuid The UUID for the ressource and path combined
+	 */
+    private void storePathUUID(Class<?> ressourceClass, Path path, UUID uuid) {
+        if (!this.pathUUID.containsKey(ressourceClass)) {
+            this.pathUUID.put(ressourceClass, new HashMap<>());
+        }
+
+        Map<Path, UUID> ressourceClassUUIDs = this.pathUUID.get(ressourceClass);
+        if (!ressourceClassUUIDs.containsKey(path)) {
+            ressourceClassUUIDs.put(path, uuid);
+        }
+    }
+
+	/**
+	 * Generate a temporary file that is a clone of the ressource
+	 *
+	 * @param ressourceClass Class which represents where the file is located
+	 * @param path Path for the ressource
+	 * @param uuid The UUID for the ressource and path combined
+	 *
+	 * @return Temporary file, that can be used as a replacement for the actual ressource file
+	 */
+    private File generateTmpFile(Class<?> ressourceClass, Path path, UUID uuid) {
+        // Get image data
+        InputStream input = getRessourceStream(ressourceClass, path);
+        if (input == null) {
+            return null;
+        }
+
+        File tmpFile;
+        try {
+            // Load file in
+            byte[] buffer = input.readAllBytes();
+            // Save file in the current directory
+			String tmpdir = System.getProperty("java.io.tmpdir");
+            tmpFile = new File(tmpdir + "/" + tmpFilePrefix + "-" + uuid + "." + tmpFileFormat);
+            tmpFile.deleteOnExit(); // Auto delete file when game closes
+            OutputStream outStream = new FileOutputStream(tmpFile);
+            outStream.write(buffer);
+        } catch (IOException ioException) {
+            return null;
+        }
+
+        return tmpFile;
+    }
+
+	/**
+	 * Get ressource as URL
+	 *
+	 * @param ressourceClass Class which represents where the file is located
+	 * @param path Path for the ressource
+	 *
+	 * @return URL representing the ressource
+	 */
+    private static URL getRessourceAsURL(Class<?> ressourceClass, Path path) {
+        return ressourceClass.getResource((resourcePrefix + path));
+    }
+
+	/**
+	 * Get ressource as stream
+	 *
+	 * @param ressourceClass Class which represents where the file is located
+	 * @param path Path for the ressource
+	 *
+	 * @return URL representing the ressource
+	 */
+    private static InputStream getRessourceStream(Class<?> ressourceClass, Path path) {
+        return ressourceClass.getResourceAsStream((resourcePrefix + path));
+    }
+}

--- a/Common/src/main/java/dk/sdu/sesem4/common/data/resource/Resource.java
+++ b/Common/src/main/java/dk/sdu/sesem4/common/data/resource/Resource.java
@@ -13,17 +13,17 @@ import java.util.UUID;
  * @author The0Mikkel & MGertz
  */
 public class Resource {
-	/** Resource file prefix. */
+    /** Resource file prefix. */
     private static final String resourcePrefix = "/";
-	/** Temporary file name prefix. */
+    /** Temporary file name prefix. */
     private static final String tmpFilePrefix = "Nelda";
-	/** Temporary file format. */
+    /** Temporary file format. */
     private static final String tmpFileFormat = "tmp";
-	/** Instance of the resource system. */
+    /** Instance of the resource system. */
     private static Resource instance;
-	/** Map of path UUIDs based on class and path. */
+    /** Map of path UUIDs based on class and path. */
     private Map<Class<?>, Map<Path, UUID>> pathUUID;
-	/** File cache, to prevent duplicate temporary files. */
+    /** File cache, to prevent duplicate temporary files. */
     private Map<UUID, File> fileCache;
 
     private Resource() {
@@ -31,11 +31,11 @@ public class Resource {
         this.fileCache = new HashMap<>();
     }
 
-	/**
-	 * Get ressource instance.
-	 *
-	 * @return Resource instance.
-	 */
+    /**
+     * Get resource instance.
+     *
+     * @return Resource instance.
+     */
     public static Resource getInstance() {
         if (Resource.instance == null) {
             Resource.instance = new Resource();
@@ -43,11 +43,12 @@ public class Resource {
         return Resource.instance;
     }
 
-	/**
-	 * Invalidate the current cache, and delete all current files used by the system.
-	 *
-	 * @throws IOException Can be thrown by the deletion process.
-	 */
+    /**
+     * Invalidate the current cache, and delete all current files used by the
+     * system.
+     *
+     * @throws IOException Can be thrown by the deletion process.
+     */
     public void invalidateCache() throws IOException {
         this.pathUUID = new HashMap<>();
 
@@ -55,82 +56,83 @@ public class Resource {
         this.fileCache = new HashMap<>();
     }
 
-	/**
-	 * Delete specific cached file
-	 *
-	 * @param file File object to delete
-	 */
-	public void deleteFile(File file) {
-		this.fileCache.values().remove(file);
-	}
+    /**
+     * Delete specific cached file
+     *
+     * @param file File object to delete
+     */
+    public void deleteFile(File file) {
+        this.fileCache.values().remove(file);
+    }
 
-	/**
-	 * Get a ressource file as a File.
-	 *
-	 * @param ressourceClass Class which represents where the file is located
-	 * @param path Path for the ressource
-	 *
-	 * @return File that has been retrieved from ressources
-	 */
-    public File getRessource(Class<?> ressourceClass, Path path) {
+    /**
+     * Get a resource file as a File.
+     *
+     * @param resourceClass Class which represents where the file is located
+     * @param path          Path for the resource
+     *
+     * @return File that has been retrieved from resources
+     */
+    public File getResource(Class<?> resourceClass, Path path) {
         // Ensure valid values
-        if (ressourceClass == null || path == null) {
+        if (resourceClass == null || path == null) {
             return null;
         }
 
-		// Get cached file
-        File cachedFile = getCachedFile(ressourceClass, path);
+        // Get cached file
+        File cachedFile = getCachedFile(resourceClass, path);
         if (cachedFile != null) {
             return cachedFile;
         }
 
-		// Generate tmp file
-        UUID uuid = generatePathUUID(ressourceClass, path);
-        File file = generateTmpFile(ressourceClass, path, uuid);
+        // Generate tmp file
+        UUID uuid = generatePathUUID(resourceClass, path);
+        File file = generateTmpFile(resourceClass, path, uuid);
         if (file == null) {
             return null;
         }
-		cacheFile(uuid, file);
+        cacheFile(uuid, file);
 
         return file;
     }
 
-	/**
-	 * Check if a ressource exists. This does not check cache.
-	 *
-	 * @param ressourceClass Class which represents where the file is located
-	 * @param path Path for the ressource
-	 *
-	 * @return Boolean representing if the ressource actually exists. True indicates the ressource is locatable.
-	 */
-    public static boolean exists(Class<?> ressourceClass, Path path) {
-        if (ressourceClass == null || path == null) {
+    /**
+     * Check if a resource exists. This does not check cache.
+     *
+     * @param resourceClass Class which represents where the file is located
+     * @param path          Path for the resource
+     *
+     * @return Boolean representing if the resource actually exists. True indicates
+     *         he resource is locatable.
+     */
+    public static boolean exists(Class<?> resourceClass, Path path) {
+        if (resourceClass == null || path == null) {
             return false;
         }
 
-        URL url = getRessourceAsURL(ressourceClass, path);
+        URL url = getResourceAsURL(resourceClass, path);
         return url != null;
     }
 
-	/**
-	 * Get cached file
-	 *
-	 * @param ressourceClass Class which represents where the file is located
-	 * @param path Path for the ressource
-	 *
-	 * @return Cached file or null if no cached file exist
-	 */
-    private File getCachedFile(Class<?> ressourceClass, Path path) {
-        return this.getCachedFile(this.getPathUUID(ressourceClass, path));
+    /**
+     * Get cached file
+     *
+     * @param resourceClass Class which represents where the file is located
+     * @param path          Path for the resource
+     *
+     * @return Cached file or null if no cached file exist
+     */
+    private File getCachedFile(Class<?> resourceClass, Path path) {
+        return this.getCachedFile(this.getPathUUID(resourceClass, path));
     }
 
-	/**
-	 * Get cached file
-	 *
-	 * @param uuid UUID representing the cached file
-	 *
-	 * @return Cached file or null if no cached file exist
-	 */
+    /**
+     * Get cached file
+     *
+     * @param uuid UUID representing the cached file
+     *
+     * @return Cached file or null if no cached file exist
+     */
     private File getCachedFile(UUID uuid) {
         if (!this.fileCache.containsKey(uuid)) {
             return null;
@@ -139,86 +141,87 @@ public class Resource {
         return this.fileCache.get(uuid);
     }
 
-	/**
-	 * Cache file
-	 *
-	 * @param uuid Representing file
-	 * @param file File to cache
-	 */
+    /**
+     * Cache file
+     *
+     * @param uuid Representing file
+     * @param file File to cache
+     */
     private void cacheFile(UUID uuid, File file) {
         this.fileCache.put(uuid, file);
     }
 
-	/**
-	 * Get path UUID, based resource class and path
-	 *
-	 * @param ressourceClass Class which represents where the file is located
-	 * @param path Path for the ressource
-	 *
-	 * @return UUID representing the unique path
-	 */
-    private UUID getPathUUID(Class<?> ressourceClass, Path path) {
-        if (!this.pathUUID.containsKey(ressourceClass)) {
+    /**
+     * Get path UUID, based resource class and path
+     *
+     * @param resourceClass Class which represents where the file is located
+     * @param path          Path for the resource
+     *
+     * @return UUID representing the unique path
+     */
+    private UUID getPathUUID(Class<?> resourceClass, Path path) {
+        if (!this.pathUUID.containsKey(resourceClass)) {
             return null;
         }
 
-        Map<Path, UUID> ressourceClassUUIDs = this.pathUUID.get(ressourceClass);
-        if (!ressourceClassUUIDs.containsKey(path)) {
+        Map<Path, UUID> resourceClassUUIDs = this.pathUUID.get(resourceClass);
+        if (!resourceClassUUIDs.containsKey(path)) {
             return null;
         }
 
-        return ressourceClassUUIDs.get(path);
+        return resourceClassUUIDs.get(path);
     }
 
-	/**
-	 * Generate path UUID, based resource class and path
-	 *
-	 * @param ressourceClass Class which represents where the file is located
-	 * @param path Path for the ressource
-	 *
-	 * @return UUID representing the unique path
-	 */
-    private UUID generatePathUUID(Class<?> ressourceClass, Path path) {
-        UUID existingUUID = getPathUUID(ressourceClass, path);
+    /**
+     * Generate path UUID, based resource class and path
+     *
+     * @param resourceClass Class which represents where the file is located
+     * @param path          Path for the resource
+     *
+     * @return UUID representing the unique path
+     */
+    private UUID generatePathUUID(Class<?> resourceClass, Path path) {
+        UUID existingUUID = getPathUUID(resourceClass, path);
         if (existingUUID != null) {
             return existingUUID;
         }
 
         UUID uuid = UUID.randomUUID();
-        storePathUUID(ressourceClass, path, uuid);
+        storePathUUID(resourceClass, path, uuid);
         return uuid;
     }
 
-	/**
-	 * Store path UUID
-	 *
-	 * @param ressourceClass Class which represents where the file is located
-	 * @param path Path for the ressource
-	 * @param uuid The UUID for the ressource and path combined
-	 */
-    private void storePathUUID(Class<?> ressourceClass, Path path, UUID uuid) {
-        if (!this.pathUUID.containsKey(ressourceClass)) {
-            this.pathUUID.put(ressourceClass, new HashMap<>());
+    /**
+     * Store path UUID
+     *
+     * @param resourceClass Class which represents where the file is located
+     * @param path          Path for the resource
+     * @param uuid          The UUID for the resource and path combined
+     */
+    private void storePathUUID(Class<?> resourceClass, Path path, UUID uuid) {
+        if (!this.pathUUID.containsKey(resourceClass)) {
+            this.pathUUID.put(resourceClass, new HashMap<>());
         }
 
-        Map<Path, UUID> ressourceClassUUIDs = this.pathUUID.get(ressourceClass);
-        if (!ressourceClassUUIDs.containsKey(path)) {
-            ressourceClassUUIDs.put(path, uuid);
+        Map<Path, UUID> resourceClassUUIDs = this.pathUUID.get(resourceClass);
+        if (!resourceClassUUIDs.containsKey(path)) {
+            resourceClassUUIDs.put(path, uuid);
         }
     }
 
-	/**
-	 * Generate a temporary file that is a clone of the ressource
-	 *
-	 * @param ressourceClass Class which represents where the file is located
-	 * @param path Path for the ressource
-	 * @param uuid The UUID for the ressource and path combined
-	 *
-	 * @return Temporary file, that can be used as a replacement for the actual ressource file
-	 */
-    private File generateTmpFile(Class<?> ressourceClass, Path path, UUID uuid) {
+    /**
+     * Generate a temporary file that is a clone of the resource
+     *
+     * @param resourceClass Class which represents where the file is located
+     * @param path          Path for the resource
+     * @param uuid          The UUID for the resource and path combined
+     *
+     * @return Temporary file, that can be used as a replacement for the actual
+     *         resource file
+     */
+    private File generateTmpFile(Class<?> resourceClass, Path path, UUID uuid) {
         // Get image data
-        InputStream input = getRessourceStream(ressourceClass, path);
+        InputStream input = getResourceStream(resourceClass, path);
         if (input == null) {
             return null;
         }
@@ -228,7 +231,7 @@ public class Resource {
             // Load file in
             byte[] buffer = input.readAllBytes();
             // Save file in the current directory
-			String tmpdir = System.getProperty("java.io.tmpdir");
+            String tmpdir = System.getProperty("java.io.tmpdir");
             tmpFile = new File(tmpdir + "/" + tmpFilePrefix + "-" + uuid + "." + tmpFileFormat);
             tmpFile.deleteOnExit(); // Auto delete file when game closes
             OutputStream outStream = new FileOutputStream(tmpFile);
@@ -240,27 +243,27 @@ public class Resource {
         return tmpFile;
     }
 
-	/**
-	 * Get ressource as URL
-	 *
-	 * @param ressourceClass Class which represents where the file is located
-	 * @param path Path for the ressource
-	 *
-	 * @return URL representing the ressource
-	 */
-    private static URL getRessourceAsURL(Class<?> ressourceClass, Path path) {
-        return ressourceClass.getResource((resourcePrefix + path));
+    /**
+     * Get resource as URL
+     *
+     * @param resourceClass Class which represents where the file is located
+     * @param path          Path for the resource
+     *
+     * @return URL representing the resource
+     */
+    private static URL getResourceAsURL(Class<?> resourceClass, Path path) {
+        return resourceClass.getResource((resourcePrefix + path));
     }
 
-	/**
-	 * Get ressource as stream
-	 *
-	 * @param ressourceClass Class which represents where the file is located
-	 * @param path Path for the ressource
-	 *
-	 * @return URL representing the ressource
-	 */
-    private static InputStream getRessourceStream(Class<?> ressourceClass, Path path) {
-        return ressourceClass.getResourceAsStream((resourcePrefix + path));
+    /**
+     * Get resource as stream
+     *
+     * @param resourceClass Class which represents where the file is located
+     * @param path          Path for the resource
+     *
+     * @return URL representing the resource
+     */
+    private static InputStream getResourceStream(Class<?> resourceClass, Path path) {
+        return resourceClass.getResourceAsStream((resourcePrefix + path));
     }
 }

--- a/Common/src/main/java/module-info.java
+++ b/Common/src/main/java/module-info.java
@@ -29,8 +29,9 @@ module Common {
 	exports dk.sdu.sesem4.common.data.gamedata;
 	exports dk.sdu.sesem4.common.data.math;
 	exports dk.sdu.sesem4.common.data.process;
-	exports dk.sdu.sesem4.common.data.weapon;
 	exports dk.sdu.sesem4.common.data.rendering;
+	exports dk.sdu.sesem4.common.data.resource;
+	exports dk.sdu.sesem4.common.data.weapon;
 	exports dk.sdu.sesem4.common.util;
 	exports dk.sdu.sesem4.common.event;
 	exports dk.sdu.sesem4.common.event.events;

--- a/Core/src/main/java/dk/sdu/sesem4/core/Game.java
+++ b/Core/src/main/java/dk/sdu/sesem4/core/Game.java
@@ -20,6 +20,7 @@ import dk.sdu.sesem4.common.data.entity.Entity;
 import dk.sdu.sesem4.common.data.gamedata.GameData;
 import dk.sdu.sesem4.common.data.process.Priority;
 import dk.sdu.sesem4.common.data.rendering.SpriteData;
+import dk.sdu.sesem4.common.data.resource.Resource;
 import dk.sdu.sesem4.common.util.SPILocator;
 
 import java.io.*;
@@ -167,29 +168,15 @@ public class Game extends ApplicationAdapter {
 		}
 
 		// Get image data
-		InputStream input = spriteData.getRessourceClass().getResourceAsStream(("/" + spriteData.getTexture()).toString());
-		File targetFile;
-		try	{
-			if (input == null) {
-				System.out.println("Sprite file is not present");
-				return null;
-			}
-			// Load file in
-			byte[] buffer = input.readAllBytes();
-			// Save file in the current directory
-			targetFile = new File("Nelda-"+key+".tmp");
-			targetFile.deleteOnExit(); // Auto delete file when game closes
-			OutputStream outStream = new FileOutputStream(targetFile);
-			outStream.write(buffer);
-		} catch (IOException ioException) {
-			System.out.println("IO exception");
+		File file = Resource.getInstance().getRessource(spriteData.getRessourceClass(), spriteData.getTexture());
+		if (file == null) {
 			return null;
 		}
 
 		// Use the absolute path from the temporary file, to load into LibGDX texture
 		Texture texture = new Texture(
 				Gdx.files.absolute(
-						targetFile.getAbsolutePath()
+						file.getAbsolutePath()
 				)
 		);
 

--- a/Core/src/main/java/dk/sdu/sesem4/core/Game.java
+++ b/Core/src/main/java/dk/sdu/sesem4/core/Game.java
@@ -177,7 +177,7 @@ public class Game extends ApplicationAdapter {
 			// Load file in
 			byte[] buffer = input.readAllBytes();
 			// Save file in the current directory
-			targetFile = new File("Nelda-"+spriteData.getId()+".tmp");
+			targetFile = new File("Nelda-"+key+".tmp");
 			targetFile.deleteOnExit(); // Auto delete file when game closes
 			OutputStream outStream = new FileOutputStream(targetFile);
 			outStream.write(buffer);

--- a/Core/src/main/java/dk/sdu/sesem4/core/Game.java
+++ b/Core/src/main/java/dk/sdu/sesem4/core/Game.java
@@ -65,7 +65,8 @@ public class Game extends ApplicationAdapter {
 	}
 
 	/**
-	 * This method is responsible for setting up the game, where the different plugins are started and the gameData is created, as well as the eventManager.
+	 * This method is responsible for setting up the game, where the different
+	 * plugins are started and the gameData is created, as well as the eventManager.
 	 */
 	@Override
 	public void create() {
@@ -106,13 +107,13 @@ public class Game extends ApplicationAdapter {
 		Gdx.graphics.getDeltaTime();
 
 		this.camera.update();
-		
+
 		renderMap();
 
 		// render sprites
 		spriteBatch.setProjectionMatrix(camera.combined);
 		spriteBatch.begin();
-		
+
 		List<Entity> entities = gameData.getGameEntities().getEntities(Entity.class);
 
 		for (Entity entity : entities) {
@@ -161,14 +162,14 @@ public class Game extends ApplicationAdapter {
 			return this.textureCache.get(key);
 		}
 
-		// Ensure ressource class has been set, otherwise crash
-		if (spriteData.getRessourceClass() == null) {
+		// Ensure resource class has been set, otherwise crash
+		if (spriteData.getResourceClass() == null) {
 			System.out.println("Resource class not set on sprite");
 			return null;
 		}
 
 		// Get image data
-		File file = Resource.getInstance().getRessource(spriteData.getRessourceClass(), spriteData.getTexture());
+		File file = Resource.getInstance().getResource(spriteData.getResourceClass(), spriteData.getTexture());
 		if (file == null) {
 			return null;
 		}
@@ -176,9 +177,7 @@ public class Game extends ApplicationAdapter {
 		// Use the absolute path from the temporary file, to load into LibGDX texture
 		Texture texture = new Texture(
 				Gdx.files.absolute(
-						file.getAbsolutePath()
-				)
-		);
+						file.getAbsolutePath()));
 
 		// Cache texture
 		this.textureCache.put(key, texture);
@@ -191,7 +190,7 @@ public class Game extends ApplicationAdapter {
 	 */
 	private void renderMap() {
 		// if there is a map, load it and render it.
-		if (gameData.getGameWorld().getMap() != null){
+		if (gameData.getGameWorld().getMap() != null) {
 			TiledMap map = loadMap(gameData.getGameWorld().getMap());
 			tiledMapRenderer = new OrthogonalTiledMapRenderer(map);
 			tiledMapRenderer.setView(camera);
@@ -201,6 +200,7 @@ public class Game extends ApplicationAdapter {
 
 	/**
 	 * This method is responsible for loading the map.
+	 * 
 	 * @param path The path to the map.
 	 * @return The map.
 	 */

--- a/Core/src/main/java/dk/sdu/sesem4/core/Game.java
+++ b/Core/src/main/java/dk/sdu/sesem4/core/Game.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * The Game class, where all process is handled and the game is rendered.
@@ -54,7 +55,7 @@ public class Game extends ApplicationAdapter {
 	/**
 	 * Cache for sprites based on file path.
 	 */
-	private Map<String, Texture> textureCache;
+	private Map<UUID, Sprite> textureCache;
 
 	public Game() {
 		this.textureCache = new HashMap<>();
@@ -120,7 +121,7 @@ public class Game extends ApplicationAdapter {
 			}
 
 			// Create sprite
-			Sprite sprite = new Sprite(getSprite(spritePart.getSprite().getTexture().toString()));
+			Sprite sprite = getSprite(spritePart);
 
 			// Set sprite size and position from entity parts
 			sprite.setSize(16, 16); // TODO: Size has to be set from entity, but this is included in a later update
@@ -143,15 +144,17 @@ public class Game extends ApplicationAdapter {
 	 * @param filePath Path for sprite
 	 * @return Sprite texture
 	 */
-	private Texture getSprite(String filePath) {
-		if (this.textureCache.containsKey(filePath)) {
-			return this.textureCache.get(filePath);
+	private Sprite getSprite(SpritePart spritePart) {
+		if (this.textureCache.containsKey(spritePart.getId())) {
+			return this.textureCache.get(spritePart.getId());
 		}
 
-		Texture texture = new Texture(Gdx.files.local(filePath));
-		this.textureCache.put(filePath, texture);
+		Texture texture = new Texture(Gdx.files.local(spritePart.getSprite().getTexture().toString()));
+		Sprite sprite = new Sprite(texture);
+		sprite.setFlip(spritePart.getSprite().isxFlipped(), spritePart.getSprite().isyFlipped());
+		this.textureCache.put(spritePart.getId(), sprite);
 
-		return texture;
+		return sprite;
 	}
 
 	/**


### PR DESCRIPTION
This closes #74 

This PR fixes the issue where sprites isn't flipped when needed.

It also fixes an issue where images weren't loaded from the JAR components, but from the folder where the files is loaded.